### PR TITLE
Use Elixir's default slice implementation

### DIFF
--- a/lib/circular_buffer.ex
+++ b/lib/circular_buffer.ex
@@ -86,8 +86,8 @@ defmodule CircularBuffer do
       Enumerable.List.reduce(CB.to_list(cb), acc, fun)
     end
 
-    def slice(cb) do
-      {:ok, cb.count, &Enumerable.List.slice(CB.to_list(cb), &1, &2)}
+    def slice(_cb) do
+      {:error, __MODULE__}
     end
   end
 

--- a/test/circular_buffer_test.exs
+++ b/test/circular_buffer_test.exs
@@ -112,6 +112,37 @@ defmodule CircularBufferTest do
     assert str == "#CircularBuffer<[1, 2, 3, 4]>"
   end
 
+  test "Enum.slice" do
+    # Verify Elixir's Enum.slice tests for lists work
+    cb = Enum.into([-2, -1, 0, 1, 2, 3, 4, 5], CB.new(5))
+    assert Enum.slice(cb, 0..0) == [1]
+    assert Enum.slice(cb, 0..1) == [1, 2]
+    assert Enum.slice(cb, 0..2) == [1, 2, 3]
+    assert Enum.slice(cb, 1, 2) == [2, 3]
+    assert Enum.slice(cb, 1, 0) == []
+    assert Enum.slice(cb, 2, 5) == [3, 4, 5]
+    assert Enum.slice(cb, 2, 6) == [3, 4, 5]
+    assert Enum.slice(cb, 5, 5) == []
+    assert Enum.slice(cb, 6, 5) == []
+    assert Enum.slice(cb, 6, 0) == []
+    assert Enum.slice(cb, -6, 0) == []
+    assert Enum.slice(cb, -6, 5) == []
+    assert Enum.slice(cb, -2, 5) == [4, 5]
+    assert Enum.slice(cb, -3, 1) == [3]
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(cb, 0, -1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(cb, 0.99, 0)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(cb, 0, 0.99)
+    end
+  end
+
   def size_and_list do
     let size <- pos_integer() do
       let is <- ints(size*2, []) do


### PR DESCRIPTION
`Enumerable.List.slice` changed in Elixir 1.10, so this fixes:

```
warning: Enumerable.List.slice/3 is undefined or private. Did you mean one of:

      * slice/1
      * slice/4

  lib/circular_buffer.ex:90: Enumerable.CircularBuffer.slice/1
```

Elixir's default slice implementation calls reduce and this change works
in Elixir 1.8 - 1.10. I didn't test earlier versions.

This commit also adds a test to verify that `Enum.slice` works at least
as well as the Elixir's implementation for lists.