### PR TITLE
Manage circular buffer using lists

### DIFF
--- a/test/circular_buffer_test.exs
+++ b/test/circular_buffer_test.exs
@@ -19,10 +19,14 @@ defmodule CircularBufferTest do
     end
   end
 
+  def slow_cb_count(cb) do
+    Enum.count(cb.a) + Enum.count(cb.b)
+  end
+
   property "the count matches the number of elements in the buffer" do
     forall {size, is} <- {pos_integer(), list(integer())} do
       buffer = Enum.reduce(is, CB.new(size), fn i, cb -> CB.insert(cb, i) end)
-      :queue.len(buffer.q) == buffer.count
+      slow_cb_count(buffer) == buffer.count
     end
   end
 
@@ -60,7 +64,7 @@ defmodule CircularBufferTest do
   property "the number of elements never exceeds the size of the buffer" do
     forall {size, is} <- size_and_list() do
       buffer = Enum.reduce(is, CB.new(size), fn i, cb -> CB.insert(cb, i) end)
-      :queue.len(buffer.q) <= size
+      slow_cb_count(buffer) <= size
     end
   end
 
@@ -74,10 +78,9 @@ defmodule CircularBufferTest do
 
       slice =
         iis
-        |> Enum.reverse
-        |> Enum.take(size)
+        |> Enum.take(-size)
 
-      :queue.to_list(buffer.q) == slice
+      CB.to_list(buffer) == slice
     end
   end
 


### PR DESCRIPTION
This switches the implementation from using the general purpose `:queue`
module to enable optimizations for the circular buffer use case. At a
high level, an Okasaki queue is still used. Since insertion to a
circular buffer always requires a removal once the buffer reaches its
max size, this change makes it possible to do this in one step.
Previously, this was a call to `:queue` to remove one element and then a
call to insert the new one.

With the general caveat on microbenchmarks, the new implementation is a
small performance improvement and reduces the garbage created when
managing the structure. The following results are from inserting items
repeatedly into a CircularBuffer. "cb2" is the new implementation and
"cb" is the `:queue` implementation in the results below.

```
Name                 ips        average  deviation         median         99th %
cb2 insert        236.18        4.23 ms     ±3.01%        4.31 ms        4.39 ms
cb insert         140.35        7.13 ms     ±3.27%        7.14 ms        7.66 ms

Comparison:
cb2 insert        236.18
cb insert         140.35 - 1.68x slower +2.89 ms

Memory usage statistics:

Name          Memory usage
cb2 insert         9.12 MB
cb insert         16.24 MB - 1.78x memory usage +7.12 MB
```
